### PR TITLE
Remove partner list and map

### DIFF
--- a/perma_web/perma/templates/about.html
+++ b/perma_web/perma/templates/about.html
@@ -96,43 +96,6 @@ Perma.cc prevents link rot.
         </div>
       </div><!--col-sm-6-->
     </div><!--row-->
-    <div class="row">
-      <div class="col-sm-12">
-        <h2 class="body-ah">Perma.cc is used and supported by libraries and institutions around the world.</h2>
-        <a href="#skip-visualizations-target" class="skip-link">Skip map and logo carousel</a>
-        {% include "includes/partner_map.html" %}
-        {% include "includes/participating_institutions.html" %}
-        <p id="skip-visualizations-target" tabindex="-1" class="sr-only">End of map and logo carousel</p>
-      </div><!--col-sm-12-->
-    </div><!--row-->
-  </div>
-</div>
-
-<div class="container cont-reading cont-fixed" id="perma-partners">
-  <div class="row">
-    <div class="col-sm-12 docs reading-body col-right">
-      <h2 class="body-ah">Perma.cc’s Partners</h2>
-      <a href="#skip-partners-target" class="skip-link">Skip partner list</a>
-      <div class="row partner-list">
-        <div class="col-sm-6  docs column reading-body">
-          {% for partner in partners_first_col %}
-          <div class="perma-partner">
-            <a href="{{ partner.website }}">{{ partner.partner_display_name|default:partner.name }}</a>
-          </div>
-          {% endfor %}
-        </div>
-        <div class="col-sm-6">
-          {% for partner in partners_last_col %}
-            <div class="perma-partner">
-              <a href="{{ partner.website }}">{{ partner.partner_display_name|default:partner.name }}</a>
-            </div>
-          {% endfor %}
-        </div>
-      </div>
-      <p id="skip-partners-target" tabindex="-1" class="sr-only">End of partner list</p>
-    </div>
-  </div>
-</div>
 
 {% endblock %}
 


### PR DESCRIPTION
Removing partner list and map from https://perma.cc/about because it is out of date and would become too visually crowded to be useful if it were fully updated. 